### PR TITLE
Fix: Can't set timers inside simulations error

### DIFF
--- a/client/components/cards/cardDate.js
+++ b/client/components/cards/cardDate.js
@@ -134,9 +134,11 @@ const CardDate = BlazeComponent.extendComponent({
     let self = this;
     self.date = ReactiveVar();
     self.now = ReactiveVar(moment());
-    Meteor.setInterval(() => {
-      self.now.set(moment());
-    }, 60000);
+    if(Meteor.isServer){
+        Meteor.setInterval(() => {
+            self.now.set(moment());
+        }, 60000);
+    }
   },
 
   showDate() {


### PR DESCRIPTION
Hello. Thanks for adding the start and due date functionality. I noticed that when I drag and drop a card with a start/due date from one list to another, I get a "Can't set timers inside simulations error". I'm not an expert in meteor but adding a check to make sure that it is running on the server seems to fix the problem.
